### PR TITLE
Add live markdown editor with debounce

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,6 +144,27 @@
             color: var(--accent-color);
             margin-bottom: 10px;
         }
+
+        .markdown-editor {
+            position: fixed;
+            top: 60px;
+            left: 20px;
+            right: 20px;
+            height: 150px;
+            z-index: 900;
+        }
+
+        #markdownEditor {
+            width: 100%;
+            height: 100%;
+            background: rgba(0, 0, 0, 0.8);
+            color: var(--primary-color);
+            border: 1px solid var(--primary-color);
+            font-family: var(--font-family);
+            font-size: 12px;
+            padding: 5px;
+            resize: vertical;
+        }
         
         @media (max-width: 768px) {
             .header {
@@ -217,7 +238,11 @@
         <h2>Drop Markdown File Here</h2>
         <p>Supports .md and .txt files</p>
     </div>
-    
+
+    <div class="markdown-editor">
+        <textarea id="markdownEditor" placeholder="Type Markdown here"></textarea>
+    </div>
+
     <script type="module" src="/src/main.ts"></script>
 </body>
 </html>

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import { applyCRTEffects, updateAnimation } from './effects.js';
 import { themes, getThemeByName, updateThemeStyles } from './theme.js';
 import { exportAsHTML, exportAsPNG, exportAsPDF } from './export.js';
 import { createTransition } from './transitions.js';
+import { debounce } from './utils.js';
 
 class SlidePresentation {
   private renderCtx: RenderContext;
@@ -76,6 +77,17 @@ Drop a Markdown file or use the file input to load your presentation.
         this.loadMarkdownFile(file);
       }
     });
+
+    // Real-time markdown editor
+    const markdownEditor = document.getElementById('markdownEditor') as HTMLTextAreaElement;
+    if (markdownEditor) {
+      const handler = debounce((value: string) => {
+        this.loadMarkdown(value);
+      }, 300);
+      markdownEditor.addEventListener('input', (e) => {
+        handler((e.target as HTMLTextAreaElement).value);
+      });
+    }
 
     // Theme selector
     const themeSelector = document.getElementById('themeSelector') as HTMLSelectElement;

--- a/tests/debounce.test.ts
+++ b/tests/debounce.test.ts
@@ -1,0 +1,13 @@
+import { debounce } from '../src/utils.js';
+
+jest.useFakeTimers();
+
+test('debounce executes after wait', () => {
+  const fn = jest.fn();
+  const debounced = debounce(fn, 100);
+  debounced();
+  debounced();
+  expect(fn).not.toBeCalled();
+  jest.advanceTimersByTime(100);
+  expect(fn).toBeCalledTimes(1);
+});


### PR DESCRIPTION
## Summary
- add a textarea for live Markdown editing
- hook up the textarea to the rendering logic using a debounced listener
- test debounce utility

## Testing
- `npm test`
- `npm run jest`


------
https://chatgpt.com/codex/tasks/task_e_684594387aec832cbe8c396c0d8ff8df