### PR TITLE
Fix markdown editor usability

### DIFF
--- a/index.html
+++ b/index.html
@@ -153,10 +153,13 @@
 
         .markdown-editor {
             position: fixed;
-            top: 60px;
-            left: 20px;
-            right: 20px;
-            height: 150px;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            height: 200px;
+            padding: 10px 20px;
+            background: rgba(0, 0, 0, 0.95);
+            border-top: 1px solid var(--primary-color);
             z-index: 900;
         }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -48,6 +48,11 @@ Drop a Markdown file or use the file input to load your presentation.
   private setupEventListeners(): void {
     // Keyboard navigation
     document.addEventListener('keydown', (e) => {
+      const target = e.target as HTMLElement;
+      if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable) {
+        return;
+      }
+
       switch (e.key) {
         case 'ArrowLeft':
           e.preventDefault();


### PR DESCRIPTION
## Summary
- reposition the markdown editor to the bottom of the screen
- prevent slide hotkeys when editing text

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845976de184832c856c1f0f34b505e8