### PR TITLE
Fix edit page assets path

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from 'vite'
 
 export default defineConfig({
+  // Use relative paths for assets so the build works when opened via file://
+  base: './',
   server: {
     host: '0.0.0.0',
     port: 3000,


### PR DESCRIPTION
## Summary
- ensure generated files work when opened via `file://` by setting `base: './'` in Vite config

## Testing
- `npm test`
- `npm run jest`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68459db70a1c832c93a8210433ac4389