### PR TITLE
Fix navigation panel overlapping issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -129,6 +129,7 @@
             padding: 5px 10px;
             border-radius: 3px;
             border: 1px solid var(--secondary-color);
+            z-index: 1001;
         }
         
         .drop-zone {


### PR DESCRIPTION
## Summary
- ensure the navigation help panel isn't hidden when the Markdown editor shifts

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6845a0d78594832cbc264ed3e8ab2f29