### PR TITLE
Fix image handling in slides

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -171,9 +171,10 @@ Drop a Markdown file or use the file input to load your presentation.
   private async loadImageFile(file: File): Promise<void> {
     try {
       const asset = await processImageFile(file);
+      this.renderCtx.images.set(file.name, asset);
       const markdownEditor = document.getElementById('markdownEditor') as HTMLTextAreaElement | null;
       if (markdownEditor) {
-        const updated = insertImageIntoMarkdown(markdownEditor.value, file.name, asset.data);
+        const updated = insertImageIntoMarkdown(markdownEditor.value, file.name);
         markdownEditor.value = updated;
         await this.loadMarkdown(updated);
       }
@@ -184,7 +185,7 @@ Drop a Markdown file or use the file input to load your presentation.
 
   private async loadMarkdown(content: string): Promise<void> {
     try {
-      this.markdownContent = await parseMarkdownSlides(content);
+      this.markdownContent = await parseMarkdownSlides(content, this.renderCtx.images);
       this.renderCtx.navigation.totalSlides = this.markdownContent.slides.length;
       this.renderCtx.navigation.currentSlide = 0;
       this.updateNavigationState();

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -132,7 +132,7 @@ export class UIManager {
         // Auto-insert into markdown if textarea has content
         const currentContent = this.markdownTextarea.value;
         if (currentContent.trim()) {
-          const newContent = insertImageIntoMarkdown(currentContent, file.name, imageAsset.data);
+          const newContent = insertImageIntoMarkdown(currentContent, file.name);
           this.markdownTextarea.value = newContent;
           this.onMarkdownChange(newContent);
         }

--- a/tests/markdown.test.ts
+++ b/tests/markdown.test.ts
@@ -21,8 +21,16 @@ describe('markdown utilities', () => {
   });
 
   test('insertImageIntoMarkdown appends image', () => {
-    const inserted = insertImageIntoMarkdown('# h', 'pic.jpg', 'dataurl');
-    expect(inserted.trim().endsWith('![pic](dataurl)')).toBe(true);
+    const inserted = insertImageIntoMarkdown('# h', 'pic.jpg');
+    expect(inserted.trim().endsWith('![pic](pic.jpg)')).toBe(true);
+  });
+
+  test('parseMarkdownSlides resolves image references', async () => {
+    const images = new Map<string, any>();
+    images.set('image.png', { name: 'image.png', data: 'data:img', width: 1, height: 1 });
+    const result = await parseMarkdownSlides(sample, images);
+    const imgEl = result.slides[0].elements.find(e => e.type === 'image');
+    expect(imgEl?.src).toBe('data:img');
   });
 
   test('validateMarkdown detects empty url', () => {


### PR DESCRIPTION
## Summary
- support image placeholder paths when editing markdown
- map placeholders to image data when parsing
- store images in render context and use map during parse
- update tests for new image logic

## Testing
- `npm test`
- `npm run jest`

------
https://chatgpt.com/codex/tasks/task_e_685bb552a560832cb4ce627ae68203f8